### PR TITLE
Feature/readme fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ retry(() => {
 });
 ```
 
-By default will retry 5 times after 500ms, 1000ms, 2000ms, 4000ms, 16000ms.
+By default will retry 5 times after 500ms, 1000ms, 2000ms, 4000ms, 8000ms.
 The number of retries, initial delay before retries and the function used to calculate retry delay can all be configured.
 
 ```javascript

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ retry(() => {
 });
 ```
 
-By default will retry 5 times after 500ms, 1000ms, 2000ms, 4000ms, 8000ms.
+By default will retry 5 times after 0.5s, 1s, 2s, 4s, 8s.
 The number of retries, initial delay before retries and the function used to calculate retry delay can all be configured.
 
 ```javascript


### PR DESCRIPTION
After implementing ember-retry in our codebase, I was wondering why the final retry only took 8s instead of 16s like the documentation stated. Turns out, the documentation was incorrect. This is a pull request to remedy that.

Thanks for a great util!