### PR TITLE
Remove public directory and robots.txt

### DIFF
--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,3 +1,0 @@
-# http://www.robotstxt.org
-User-agent: *
-Disallow:


### PR DESCRIPTION
This appears to be an autogenerated file  from ember-cli, but it should not be here. 
The presence of this directory/file means that every consuming app gets a `ember-rety/robots.txt` merged into it's `dist` directory when the app is built.